### PR TITLE
Retain JS comments that're flagged for it

### DIFF
--- a/minify.sh
+++ b/minify.sh
@@ -75,7 +75,7 @@ do
                     if [ ! "$NP" = "true" ]; then
                         MAP_OP="--source-map ${filename}.min.$filetype.map"
                     fi
-                    "$MYPATH/node_modules/uglify-js/bin/uglifyjs" --mangle --compress if_return=true $MAP_OP -o "${filename}.min.$filetype" "${filename}.$filetype"
+                    "$MYPATH/node_modules/uglify-js/bin/uglifyjs" --mangle --comments="/^!/" --compress if_return=true $MAP_OP -o "${filename}.min.$filetype" "${filename}.$filetype"
                 fi
                 if [ ! $? -eq 0 ]; then
                     echo.Red "local compressor failed, now try to compress with javascript-/cssminifier.com"


### PR DESCRIPTION
Comment blocks that start with `/*!` are trying to flag themselves as licenses, and should be left in minified source for copyright purposes.