### PR TITLE
Fix use of online services for minification

### DIFF
--- a/minify.sh
+++ b/minify.sh
@@ -24,8 +24,8 @@ fi
 types=(js css)
 #For storing the URL of API to minify the files
 declare -A urls
-urls[js]="http://javascript-minifier.com/raw"
-urls[css]="http://cssminifier.com/raw"
+urls[js]="https://javascript-minifier.com/raw"
+urls[css]="https://cssminifier.com/raw"
 
 echo.BoldCyan "Scaning direcotry..."
 

--- a/minify.sh
+++ b/minify.sh
@@ -67,7 +67,7 @@ do
                 fi
                 if [ ! $? -eq 0 ]; then
                     echo.Red "local compressor failed, now try to compress with javascript-/cssminifier.com"
-                    curl -X POST -s --data-urlencode "input@${filename}.$filetype" ${urls[$filetype]} > "${filename}.min.$filetype"
+                    curl -X POST -L --max-redirs 0 -sS -f -o "${filename}.min.$filetype" --data-urlencode "input@${filename}.$filetype" ${urls[$filetype]}
                 fi
             fi
         done


### PR DESCRIPTION
This pull request is a fix for issue #18.

The root cause was that the URLs now need to be HTTPS instead of HTTP.

I have also modified the curl invocation so that failures to invoke the service will not have the error page written to the minified output page (including redirects).